### PR TITLE
Remove unnecessary function

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -1,11 +1,7 @@
 import { isDocker } from "./mod.ts";
 
-const cli = async () => {
-  if (await isDocker()) {
-  console.log('You are inside docker environment!');
-  } else {
+if (await isDocker()) {
+    console.log('You are inside docker environment!');
+} else {
     console.log('You are not in docker environment!');
-  }
 }
-
-cli();


### PR DESCRIPTION
Since deno supports top-level await, you don't need this function, just a refactoring.